### PR TITLE
correct reference number

### DIFF
--- a/R/next_tuesday.R
+++ b/R/next_tuesday.R
@@ -6,7 +6,7 @@
 next_tuesday <- function() {
     todays_date <- lubridate::today(tz = "America/New_York")
 
-    diff_tuesday <- 3 - lubridate::wday(todays_date)
+    diff_tuesday <- 2 - lubridate::wday(todays_date)
 
     if (diff_tuesday < 0) {
         diff_tuesday <- diff_tuesday + 7


### PR DESCRIPTION
lubridate::wday starts with monday = 1, not sunday.

I was working on a tidytemplate, and was trying to use this function.